### PR TITLE
fix(elementTemplate): edit element-template-generation-plugin

### DIFF
--- a/connect/core/element-template-api/src/main/java/io/miragon/miranum/connect/elementtemplate/api/ElementTemplate.java
+++ b/connect/core/element-template-api/src/main/java/io/miragon/miranum/connect/elementtemplate/api/ElementTemplate.java
@@ -35,5 +35,5 @@ public @interface ElementTemplate {
      *
      * @return the version of the element template
      */
-    int version() default 1;
+    int version() default -1;
 }

--- a/connect/core/element-template-api/src/main/java/io/miragon/miranum/connect/elementtemplate/api/ElementTemplate.java
+++ b/connect/core/element-template-api/src/main/java/io/miragon/miranum/connect/elementtemplate/api/ElementTemplate.java
@@ -35,5 +35,5 @@ public @interface ElementTemplate {
      *
      * @return the version of the element template
      */
-    String version() default "0-1";
+    int version() default 1;
 }

--- a/connect/templates/camunda7/src/test/java/io/miragon/miranum/connect/elementtemplates/c7/Camunda7ElementTemplateGeneratorTest.java
+++ b/connect/templates/camunda7/src/test/java/io/miragon/miranum/connect/elementtemplates/c7/Camunda7ElementTemplateGeneratorTest.java
@@ -25,7 +25,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class));
@@ -48,7 +48,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -72,7 +72,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInputWithElementTemplatePropertyAnnotation.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class));

--- a/connect/templates/camunda7/src/test/java/io/miragon/miranum/connect/elementtemplates/c7/Camunda7ElementTemplateGeneratorTest.java
+++ b/connect/templates/camunda7/src/test/java/io/miragon/miranum/connect/elementtemplates/c7/Camunda7ElementTemplateGeneratorTest.java
@@ -5,6 +5,7 @@ import io.miragon.miranum.connect.elementtemplate.api.PropertyType;
 import io.miragon.miranum.connect.elementtemplate.c7.Camunda7ElementTemplateGenerator;
 import io.miragon.miranum.connect.elementtemplate.core.ElementTemplateInfo;
 import io.miragon.miranum.connect.elementtemplate.core.ElementTemplateInfoMapper;
+import io.miragon.miranum.connect.elementtemplate.core.InputValueNamingPolicy;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,7 +26,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class));
@@ -33,7 +34,7 @@ class Camunda7ElementTemplateGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template.json"));
 
         // Act
-        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
 
         // Assert
         assertNotNull(result.getJson());
@@ -48,7 +49,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 new ArrayList<>(),
                 new ArrayList<>());
@@ -56,7 +57,7 @@ class Camunda7ElementTemplateGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-no-input-and-output.json"));
 
         // Act
-        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
 
         // Assert
         assertNotNull(result.getJson());
@@ -72,7 +73,7 @@ class Camunda7ElementTemplateGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInputWithElementTemplatePropertyAnnotation.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class));
@@ -80,7 +81,55 @@ class Camunda7ElementTemplateGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-annotated-input-properties.json"));
 
         // Act
-        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
+
+        // Assert
+        assertNotNull(result.getJson());
+        assertEquals(expectedJsonResult, result.getJson());
+    }
+
+    @Test
+    void generateCamunda7ElementTemplate_withNoInputAndOutputTypes_shouldReturnValidOutputWithVersion() throws IOException {
+        // Arrange
+        Camunda7ElementTemplateGenerator camunda7ElementTemplateGenerator = new Camunda7ElementTemplateGenerator();
+        var elementTemplateInfo = new ElementTemplateInfo(
+                "Test",
+                "test",
+                "test",
+                1,
+                "test",
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+        var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-version.json"));
+
+        // Act
+        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
+
+        // Assert
+        assertNotNull(result.getJson());
+        assertEquals(expectedJsonResult, result.getJson());
+    }
+
+    @Test
+    void generateCamunda7ElementTemplate_withValidInput_shouldReturnValidOutputWithNamedInputValues() throws IOException {
+        // Arrange
+        Camunda7ElementTemplateGenerator camunda7ElementTemplateGenerator = new Camunda7ElementTemplateGenerator();
+        var elementTemplateInfo = new ElementTemplateInfo(
+                "Test",
+                "test",
+                "test",
+                -1,
+                "test",
+                ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
+                new ArrayList<>()
+        );
+
+        var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-named-input-values.json"));
+
+        // Act
+        var result = camunda7ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.ATTRIBUTE_NAME);
 
         // Assert
         assertNotNull(result.getJson());

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template-no-input-and-output.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template-no-input-and-output.json
@@ -2,6 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
+  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
@@ -2,7 +2,6 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
-  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",
@@ -42,7 +41,7 @@
       "notEmpty" : false
     }
   }, {
-    "value" : "nameResult",
+    "value" : "name",
     "label" : "Output: name",
     "type" : "String",
     "binding" : {
@@ -50,7 +49,7 @@
       "source" : "${name}"
     }
   }, {
-    "value" : "idResult",
+    "value" : "id",
     "label" : "Output: id",
     "type" : "String",
     "binding" : {

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
@@ -2,6 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
+  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",
@@ -22,16 +23,16 @@
       "name" : "camunda:topic"
     }
   }, {
-    "value" : "",
-    "label" : "Property1",
+    "value" : "${}",
+    "label" : "Input: Property1",
     "type" : "Text",
     "binding" : {
       "type" : "camunda:inputParameter",
       "name" : "name"
     }
   }, {
-    "value" : "",
-    "label" : "Property2",
+    "value" : "${}",
+    "label" : "Input: Property2",
     "type" : "String",
     "binding" : {
       "type" : "camunda:inputParameter",
@@ -42,7 +43,7 @@
     }
   }, {
     "value" : "nameResult",
-    "label" : "name",
+    "label" : "Output: name",
     "type" : "String",
     "binding" : {
       "type" : "camunda:outputParameter",
@@ -50,7 +51,7 @@
     }
   }, {
     "value" : "idResult",
-    "label" : "id",
+    "label" : "Output: id",
     "type" : "String",
     "binding" : {
       "type" : "camunda:outputParameter",

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-named-input-values.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-named-input-values.json
@@ -21,5 +21,21 @@
       "type" : "property",
       "name" : "camunda:topic"
     }
+  }, {
+    "value" : "${name}",
+    "label" : "Input: name",
+    "type" : "String",
+    "binding" : {
+      "type" : "camunda:inputParameter",
+      "name" : "name"
+    }
+  }, {
+    "value" : "${id}",
+    "label" : "Input: id",
+    "type" : "String",
+    "binding" : {
+      "type" : "camunda:inputParameter",
+      "name" : "id"
+    }
   } ]
 }

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-version.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template-with-version.json
@@ -2,6 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
+  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template.json
@@ -2,7 +2,6 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
-  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",
@@ -39,7 +38,7 @@
       "name" : "id"
     }
   }, {
-    "value" : "nameResult",
+    "value" : "name",
     "label" : "Output: name",
     "type" : "String",
     "binding" : {
@@ -47,7 +46,7 @@
       "source" : "${name}"
     }
   }, {
-    "value" : "idResult",
+    "value" : "id",
     "label" : "Output: id",
     "type" : "String",
     "binding" : {

--- a/connect/templates/camunda7/src/test/resources/expected-test-element-template.json
+++ b/connect/templates/camunda7/src/test/resources/expected-test-element-template.json
@@ -2,6 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
   "name" : "Test",
   "id" : "test",
+  "version" : 1.0,
   "appliesTo" : [ "bpmn:ServiceTask" ],
   "properties" : [ {
     "value" : "external",
@@ -22,16 +23,16 @@
       "name" : "camunda:topic"
     }
   }, {
-    "value" : "",
-    "label" : "name",
+    "value" : "${}",
+    "label" : "Input: name",
     "type" : "String",
     "binding" : {
       "type" : "camunda:inputParameter",
       "name" : "name"
     }
   }, {
-    "value" : "",
-    "label" : "id",
+    "value" : "${}",
+    "label" : "Input: id",
     "type" : "String",
     "binding" : {
       "type" : "camunda:inputParameter",
@@ -39,7 +40,7 @@
     }
   }, {
     "value" : "nameResult",
-    "label" : "name",
+    "label" : "Output: name",
     "type" : "String",
     "binding" : {
       "type" : "camunda:outputParameter",
@@ -47,7 +48,7 @@
     }
   }, {
     "value" : "idResult",
-    "label" : "id",
+    "label" : "Output: id",
     "type" : "String",
     "binding" : {
       "type" : "camunda:outputParameter",

--- a/connect/templates/camunda8/src/main/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplateGenerator.java
+++ b/connect/templates/camunda8/src/main/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplateGenerator.java
@@ -19,6 +19,7 @@ public class Camunda8ElementTemplateGenerator implements ElementTemplateGenerato
         var elementTemplate = new CamundaC8ElementTemplate()
                 .setName(elementTemplateInfo.getName())
                 .setId(elementTemplateInfo.getId())
+                .setVersion(elementTemplateInfo.getVersion())
                 .setAppliesTo(List.of(BPMNElementType.BPMN_SERVICE_TASK.getValue()));
 
         // Add property for the topic of the worker
@@ -35,13 +36,13 @@ public class Camunda8ElementTemplateGenerator implements ElementTemplateGenerato
 
         // Add properties for input parameters
         for (var inputProperty : elementTemplateInfo.getInputProperties()) {
-            var property = createPropertyWithValue(inputProperty, false);
+            var property = createInputParameterProp(inputProperty);
             elementTemplate.getProperties().add(property);
         }
 
         // Add properties for output parameters
         for (var outputProperties : elementTemplateInfo.getOutputProperties()) {
-            var property = createPropertyWithValue(outputProperties, true);
+            var property = createOutputParameterProp(outputProperties);
             elementTemplate.getProperties().add(property);
         }
 
@@ -49,29 +50,42 @@ public class Camunda8ElementTemplateGenerator implements ElementTemplateGenerato
         return new ElementTemplateGenerationResult(
                 elementTemplateInfo.getId(),
                 elementTemplateInfo.getVersion(),
-                json,
-                TargetPlatform.camunda8
+                json
         );
     }
 
-    private Property createPropertyWithValue(ElementTemplatePropertyInfo info, boolean output) {
-        var value = output ? info.getLabel() + "Result" : "=";
-        var bindingType = output ? Binding.Type.ZEEBE_OUTPUT : Binding.Type.ZEEBE_INPUT;
+    private Property createInputParameterProp(ElementTemplatePropertyInfo info) {
         var property = new Property()
-                .setLabel(info.getLabel())
+                .setLabel("Input: %s".formatted(info.getLabel()))
+                .setValue("=%s".formatted(info.getName()))
                 .setType(info.getType().getType())
                 .setChoices(null)
                 .setBinding(new Binding()
-                        .setType(bindingType))
-                .setValue(value);
+                        .setType(Binding.Type.ZEEBE_INPUT)
+                        .setName(info.getName()));
 
-        if (output) {
-            property.getBinding().setSource("=" + info.getLabel());
-        } else {
-            property.getBinding().setName(info.getName());
+        if (!info.isNotEmpty()) {
+            property.setConstraints(new Constraints()
+                    .setNotEmpty(info.isNotEmpty()));
         }
 
-        // Only set if false, else jackson will display default value in generated json
+        if (!info.isEditable()) {
+            property.setEditable(info.isEditable());
+        }
+
+        return property;
+    }
+
+    private Property createOutputParameterProp(ElementTemplatePropertyInfo info) {
+        var property = new Property()
+                .setLabel("Output: %s".formatted(info.getLabel()))
+                .setValue("%sResult".formatted(info.getName()))
+                .setType(info.getType().getType())
+                .setChoices(null)
+                .setBinding(new Binding()
+                        .setType(Binding.Type.ZEEBE_OUTPUT)
+                        .setSource("=%s".formatted(info.getName())));
+
         if (!info.isNotEmpty()) {
             property.setConstraints(new Constraints()
                     .setNotEmpty(info.isNotEmpty()));

--- a/connect/templates/camunda8/src/test/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplatesGeneratorTest.java
+++ b/connect/templates/camunda8/src/test/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplatesGeneratorTest.java
@@ -6,6 +6,7 @@ import io.miragon.miranum.connect.elementtemplate.api.ElementTemplateProperty;
 import io.miragon.miranum.connect.elementtemplate.api.PropertyType;
 import io.miragon.miranum.connect.elementtemplate.core.ElementTemplateInfo;
 import io.miragon.miranum.connect.elementtemplate.core.ElementTemplateInfoMapper;
+import io.miragon.miranum.connect.elementtemplate.core.InputValueNamingPolicy;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,7 +26,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class)
@@ -34,7 +35,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template.json"));
 
         // Act
-        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
 
         // Create JsonNodes because the order of the properties is irrelevant
         ObjectMapper objectMapper = new ObjectMapper();
@@ -54,7 +55,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 new ArrayList<>(),
                 new ArrayList<>()
@@ -63,7 +64,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-no-input-and-output.json"));
 
         // Act
-        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
 
         // Create JsonNodes because the order of the properties is irrelevant
         ObjectMapper objectMapper = new ObjectMapper();
@@ -83,7 +84,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                1,
+                -1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInputWithElementTemplatePropertyAnnotation.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class)
@@ -92,7 +93,65 @@ public class Camunda8ElementTemplatesGeneratorTest {
         var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-annotated-input-properties.json"));
 
         // Act
-        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo);
+        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
+
+        // Create JsonNodes because the order of the properties is irrelevant
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode expectedJsonObject = objectMapper.readTree(expectedJsonResult);
+        JsonNode generatedJsonObject = objectMapper.readTree(result.getJson());
+
+        // Assert
+        assertNotNull(generatedJsonObject);
+        assertEquals(expectedJsonObject, generatedJsonObject);
+    }
+
+    @Test
+    void generateCamunda8ElementTemplate_withNoInputAndOutputTypes_shouldReturnValidOutputWithVersion() throws IOException {
+        // Arrange
+        Camunda8ElementTemplateGenerator camunda8ElementTemplateGenerator = new Camunda8ElementTemplateGenerator();
+        var elementTemplateInfo = new ElementTemplateInfo(
+                "Test",
+                "test",
+                "test",
+                1,
+                "test",
+                new ArrayList<>(),
+                new ArrayList<>()
+        );
+
+        var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-version.json"));
+
+        // Act
+        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.EMPTY);
+
+        // Create JsonNodes because the order of the properties is irrelevant
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode expectedJsonObject = objectMapper.readTree(expectedJsonResult);
+        JsonNode generatedJsonObject = objectMapper.readTree(result.getJson());
+
+        // Assert
+        assertNotNull(generatedJsonObject);
+        assertEquals(expectedJsonObject, generatedJsonObject);
+    }
+
+    @Test
+    void generateCamunda8ElementTemplate_withValidInput_shouldReturnValidOutputWithNamedInputValue() throws IOException {
+        // Arrange
+        Camunda8ElementTemplateGenerator camunda8ElementTemplateGenerator = new Camunda8ElementTemplateGenerator();
+        var elementTemplateInfo = new ElementTemplateInfo(
+                "Test",
+                "test",
+                "test",
+                -1,
+                "test",
+                ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
+                new ArrayList<>()
+        );
+
+        var expectedJsonResult = Files.readString(Path.of("./src/test/resources/expected-test-element-template-with-named-input-values.json"));
+
+        // Act
+        var result = camunda8ElementTemplateGenerator.generate(elementTemplateInfo, InputValueNamingPolicy.ATTRIBUTE_NAME);
 
         // Create JsonNodes because the order of the properties is irrelevant
         ObjectMapper objectMapper = new ObjectMapper();

--- a/connect/templates/camunda8/src/test/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplatesGeneratorTest.java
+++ b/connect/templates/camunda8/src/test/java/io/miragon/miranum/connect/elementtemplate/c8/Camunda8ElementTemplatesGeneratorTest.java
@@ -25,7 +25,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInput.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class)
@@ -54,7 +54,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 new ArrayList<>(),
                 new ArrayList<>()
@@ -83,7 +83,7 @@ public class Camunda8ElementTemplatesGeneratorTest {
                 "Test",
                 "test",
                 "test",
-                "0-1",
+                1,
                 "test",
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestInputWithElementTemplatePropertyAnnotation.class),
                 ElementTemplateInfoMapper.mapTypeToElementTemplateInfos(TestOutput.class)

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template-no-input-and-output.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template-no-input-and-output.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
+  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
-  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],
@@ -18,7 +17,7 @@
       }
     },
     {
-      "value": "=name",
+      "value": "=",
       "label": "Input: Property1",
       "type": "Text",
       "binding": {
@@ -27,7 +26,7 @@
       }
     },
     {
-      "value": "=id",
+      "value": "=",
       "label": "Input: Property2",
       "type": "String",
       "constraints": {
@@ -39,7 +38,7 @@
       }
     },
     {
-      "value": "nameResult",
+      "value": "name",
       "label": "Output: name",
       "type": "String",
       "binding": {
@@ -48,7 +47,7 @@
       }
     },
     {
-      "value": "idResult",
+      "value": "id",
       "label": "Output: id",
       "type": "String",
       "binding": {

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-annotated-input-properties.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
+  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],
@@ -17,8 +18,8 @@
       }
     },
     {
-      "value": "=",
-      "label": "Property1",
+      "value": "=name",
+      "label": "Input: Property1",
       "type": "Text",
       "binding": {
         "type": "zeebe:input",
@@ -26,8 +27,8 @@
       }
     },
     {
-      "value": "=",
-      "label": "Property2",
+      "value": "=id",
+      "label": "Input: Property2",
       "type": "String",
       "constraints": {
         "notEmpty": false
@@ -39,7 +40,7 @@
     },
     {
       "value": "nameResult",
-      "label": "name",
+      "label": "Output: name",
       "type": "String",
       "binding": {
         "type": "zeebe:output",
@@ -48,7 +49,7 @@
     },
     {
       "value": "idResult",
-      "label": "id",
+      "label": "Output: id",
       "type": "String",
       "binding": {
         "type": "zeebe:output",

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-named-input-values.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-named-input-values.json
@@ -15,6 +15,24 @@
       "binding": {
         "type": "zeebe:taskDefinition:type"
       }
+    },
+    {
+      "value": "=name",
+      "label": "Input: name",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "name"
+      }
+    },
+    {
+      "value": "=id",
+      "label": "Input: id",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "id"
+      }
     }
   ]
 }

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-version.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template-with-version.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
+  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template.json
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
-  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],
@@ -18,7 +17,7 @@
       }
     },
     {
-      "value": "=name",
+      "value": "=",
       "label": "Input: name",
       "type": "String",
       "binding": {
@@ -27,7 +26,7 @@
       }
     },
     {
-      "value": "=id",
+      "value": "=",
       "label": "Input: id",
       "type": "String",
       "binding": {
@@ -36,7 +35,7 @@
       }
     },
     {
-      "value": "nameResult",
+      "value": "name",
       "label": "Output: name",
       "type": "String",
       "binding": {
@@ -45,7 +44,7 @@
       }
     },
     {
-      "value": "idResult",
+      "value": "id",
       "label": "Output: id",
       "type": "String",
       "binding": {

--- a/connect/templates/camunda8/src/test/resources/expected-test-element-template.json
+++ b/connect/templates/camunda8/src/test/resources/expected-test-element-template.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.8.0/resources/schema.json",
   "name": "Test",
   "id": "test",
+  "version": 1,
   "appliesTo": [
     "bpmn:ServiceTask"
   ],
@@ -17,8 +18,8 @@
       }
     },
     {
-      "value": "=",
-      "label": "name",
+      "value": "=name",
+      "label": "Input: name",
       "type": "String",
       "binding": {
         "type": "zeebe:input",
@@ -26,8 +27,8 @@
       }
     },
     {
-      "value": "=",
-      "label": "id",
+      "value": "=id",
+      "label": "Input: id",
       "type": "String",
       "binding": {
         "type": "zeebe:input",
@@ -36,7 +37,7 @@
     },
     {
       "value": "nameResult",
-      "label": "name",
+      "label": "Output: name",
       "type": "String",
       "binding": {
         "type": "zeebe:output",
@@ -45,7 +46,7 @@
     },
     {
       "value": "idResult",
-      "label": "id",
+      "label": "Output: id",
       "type": "String",
       "binding": {
         "type": "zeebe:output",

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerationResult.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerationResult.java
@@ -13,7 +13,10 @@ public class ElementTemplateGenerationResult {
 
     private String json;
 
+    private TargetPlatform targetPlatform;
+
     public String getFileName() {
-        return  "%s-v%s.json".formatted(name, version);
+        var v = version > 0 ? "-v%s".formatted(version) : "";
+        return  "%s%s.json".formatted(name, v);
     }
 }

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerationResult.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerationResult.java
@@ -9,13 +9,11 @@ public class ElementTemplateGenerationResult {
 
     private String name;
 
-    private String version;
+    private int version;
 
     private String json;
 
-    private TargetPlatform targetPlatform;
-
     public String getFileName() {
-        return name + "-" + version + ".json";
+        return  "%s-v%s.json".formatted(name, version);
     }
 }

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerator.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateGenerator.java
@@ -2,5 +2,5 @@ package io.miragon.miranum.connect.elementtemplate.core;
 
 public interface ElementTemplateGenerator {
 
-    ElementTemplateGenerationResult generate(ElementTemplateInfo elementTemplateInfo);
+    ElementTemplateGenerationResult generate(ElementTemplateInfo elementTemplateInfo, InputValueNamingPolicy inputValueNamingPolicy);
 }

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfo.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfo.java
@@ -15,7 +15,7 @@ public class ElementTemplateInfo {
 
     private final String id;
 
-    private final String version;
+    private final int version;
 
     private final String type;
 

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfoMapper.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfoMapper.java
@@ -34,7 +34,7 @@ public class ElementTemplateInfoMapper {
                 Objects.nonNull(elementTemplate) ? elementTemplate.name() : method.getName(),
                 Objects.nonNull(elementTemplate) ? elementTemplate.description() : null,
                 worker.type(),
-                Objects.nonNull(elementTemplate) ? elementTemplate.version() : "0-1",
+                Objects.nonNull(elementTemplate) ? elementTemplate.version() : 1,
                 worker.type(),
                 inputProperties,
                 outputProperties

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfoMapper.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/ElementTemplateInfoMapper.java
@@ -34,7 +34,7 @@ public class ElementTemplateInfoMapper {
                 Objects.nonNull(elementTemplate) ? elementTemplate.name() : method.getName(),
                 Objects.nonNull(elementTemplate) ? elementTemplate.description() : null,
                 worker.type(),
-                Objects.nonNull(elementTemplate) ? elementTemplate.version() : 1,
+                Objects.nonNull(elementTemplate) ? elementTemplate.version() : -1,
                 worker.type(),
                 inputProperties,
                 outputProperties

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/InputValueNamingPolicy.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/InputValueNamingPolicy.java
@@ -1,0 +1,5 @@
+package io.miragon.miranum.connect.elementtemplate.core;
+
+public enum InputValueNamingPolicy {
+    EMPTY, ATTRIBUTE_NAME
+}

--- a/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/TargetPlatform.java
+++ b/connect/templates/generator-maven-plugin-core/src/main/java/io/miragon/miranum/connect/elementtemplate/core/TargetPlatform.java
@@ -1,5 +1,5 @@
 package io.miragon.miranum.connect.elementtemplate.core;
 
 public enum TargetPlatform {
-    camunda7, camunda8
+    C7, C8
 }

--- a/connect/templates/generator-maven-plugin/README.md
+++ b/connect/templates/generator-maven-plugin/README.md
@@ -1,0 +1,149 @@
+# Element Template Generator Plugin
+
+## Usage
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.miragon.miranum</groupId>
+            <artifactId>element-templates-generator-maven-plugin</artifactId>
+            <configuration>
+                <targetPlatform>C7</targetPlatform>
+                <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
+                <inputNamingPolicy>ATTRIBUTE_NAME</inputNamingPolicy>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+### Configuration
+
+| Name                |                | Description                                                      | Possible Values           | Default Value                                                    |
+|---------------------|----------------|------------------------------------------------------------------|---------------------------|------------------------------------------------------------------|
+| `targetPlatform`    | **(required)** | The target platform for which the templates should be generated. | `C7`, `C8`                | None                                                             |
+| `outputDirectory`   | **(optional)** | The directory where the generated templates should be saved.     | Any valid path            | `${project.build.directory/generated-sources/element-templates}` |
+| `inputNamingPolicy` | **(optional)** | The naming policy for the input value.                           | `EMPTY`, `ATTRIBUTE_NAME` | `EMPTY`                                                          |
+
+> :information_source: 
+> **Note:** The `inputNamingPolicy` is only relevant for the generation of the input value. 
+> The default value `EMPTY` will generate an empty input value. 
+> The value `ATTRIBUTE_NAME` will generate an input value with the name of the attribute.
+> ```xml
+> <configuration>
+>    <targetPlatform>C7</targetPlatform>
+>    <inputNamingPolicy>EMPTY</inputNamingPolicy>
+> </configuration>
+> ```
+>  
+> | `inputNamingPolicy` | Result                                                                                                                                                                                                                                                                                                                                  |
+> |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | `EMPTY`             | {<br>&nbsp;&nbsp;<code>"value" : "${}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br>        |
+> | `ATTRIBUTE_NAME`    | {<br>&nbsp;&nbsp;<code>"value" : "${orderId}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br> |
+
+### Annotations
+
+It is **optional** to use annotations to provide additional information about the desired output.
+1. `@ElementTemplate()`
+2. `@ElementTemplateProperty()`
+
+```java
+import io.miragon.miranum.connect.elementtemplate.api.ElementTemplateProperty;
+
+public class MiranumWorkerAdapter {
+    @Worker(type = "orderProcess")
+    @ElementTemplate(name = "Order Process", description = "Processes an incoming order.", version = 1)
+    public OrderResult processOrder(OrderDto order) {
+        // process order
+    }
+}
+
+class OrderDto {
+    @ElementTemplateProperty(type = "String", label = "Order ID", notEmpty = true, editable = false)
+    private String orderId;
+    @ElementTemplateProperty(type = "String", label = "Order Value", notEmpty = true, editable = false)
+    private String orderValue;
+}
+
+class OrderResult {
+    @ElementTemplateProperty(type = "String", label = "Delivery Date", notEmpty = true, editable = false)
+    private String deliveryDate;
+}
+```
+
+## Minimal Example
+
+### Camunda 7
+
+```java
+public class MiranumWorkerAdapter {
+    @Worker(type="orderProcess")
+    public OrderResult processOrder(OrderDto order) {
+        // process order
+    }
+}
+
+class OrderDto {
+    private String orderId;
+    private String orderValue;
+}
+
+class OrderResult {
+    private String deliveryDate;
+}
+```
+
+```json
+{
+  "$schema" : "https://unpkg.com/@camunda/element-templates-json-schema@0.1.0/resources/schema.json",
+  "name" : "orderProcess",
+  "id" : "orderProcess",
+  "appliesTo" : [ "bpmn:ServiceTask" ],
+  "properties" : [ {
+    "value" : "external",
+    "label" : "Implementation Type",
+    "type" : "String",
+    "editable" : false,
+    "binding" : {
+      "type" : "property",
+      "name" : "camunda:type"
+    }
+  }, {
+    "value" : "orderProcess",
+    "label" : "Topic",
+    "type" : "String",
+    "editable" : false,
+    "binding" : {
+      "type" : "property",
+      "name" : "camunda:topic"
+    }
+  }, {
+    "value" : "${}",
+    "label" : "Input: orderId",
+    "type" : "String",
+    "editable" : true,
+    "binding" : {
+      "type" : "camunda:inputParameter",
+      "name" : "orderId"
+    }
+  }, {
+    "value" : "${}",
+    "label" : "Input: orderValue",
+    "type" : "String",
+    "editable" : true,
+    "binding" : {
+      "type" : "camunda:inputParameter",
+      "name" : "orderValue"
+    }
+  }, {
+    "value" : "deliveryDate",
+    "label" : "Output: deliveryDate",
+    "type" : "String",
+    "binding" : {
+      "type" : "camunda:outputParameter",
+      "source" : "${deliveryDate}"
+    }
+  } ]
+}
+```

--- a/connect/templates/generator-maven-plugin/README.md
+++ b/connect/templates/generator-maven-plugin/README.md
@@ -11,7 +11,7 @@
             <configuration>
                 <targetPlatform>C7</targetPlatform>
                 <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-                <inputNamingPolicy>ATTRIBUTE_NAME</inputNamingPolicy>
+                <inputValueNamingPolicy>ATTRIBUTE_NAME</inputValueNamingPolicy>
             </configuration>
         </plugin>
     </plugins>
@@ -20,27 +20,27 @@
 
 ### Configuration
 
-| Name                |                | Description                                                      | Possible Values           | Default Value                                                    |
-|---------------------|----------------|------------------------------------------------------------------|---------------------------|------------------------------------------------------------------|
-| `targetPlatform`    | **(required)** | The target platform for which the templates should be generated. | `C7`, `C8`                | None                                                             |
-| `outputDirectory`   | **(optional)** | The directory where the generated templates should be saved.     | Any valid path            | `${project.build.directory/generated-sources/element-templates}` |
-| `inputNamingPolicy` | **(optional)** | The naming policy for the input value.                           | `EMPTY`, `ATTRIBUTE_NAME` | `EMPTY`                                                          |
+| Name                     |                | Description                                                      | Possible Values           | Default Value                                                    |
+|--------------------------|----------------|------------------------------------------------------------------|---------------------------|------------------------------------------------------------------|
+| `targetPlatform`         | **(required)** | The target platform for which the templates should be generated. | `C7`, `C8`                | None                                                             |
+| `outputDirectory`        | **(optional)** | The directory where the generated templates should be saved.     | Any valid path            | `${project.build.directory/generated-sources/element-templates}` |
+| `inputValueNamingPolicy` | **(optional)** | The naming policy for the input value.                           | `EMPTY`, `ATTRIBUTE_NAME` | `EMPTY`                                                          |
 
 > :information_source: 
-> **Note:** The `inputNamingPolicy` is only relevant for the generation of the input value. 
+> **Note:** The `inputValueNamingPolicy` is only relevant for the generation of the input value. 
 > The default value `EMPTY` will generate an empty input value. 
 > The value `ATTRIBUTE_NAME` will generate an input value with the name of the attribute.
 > ```xml
 > <configuration>
 >    <targetPlatform>C7</targetPlatform>
->    <inputNamingPolicy>EMPTY</inputNamingPolicy>
+>    <inputValueNamingPolicy>EMPTY</inputValueNamingPolicy>
 > </configuration>
 > ```
 >  
-> | `inputNamingPolicy` | Result                                                                                                                                                                                                                                                                                                                                  |
-> |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> | `EMPTY`             | {<br>&nbsp;&nbsp;<code>"value" : "${}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br>        |
-> | `ATTRIBUTE_NAME`    | {<br>&nbsp;&nbsp;<code>"value" : "${orderId}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br> |
+> | `inputValueNamingPolicy` | Result                                                                                                                                                                                                                                                                                                                                  |
+> |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | `EMPTY`                  | {<br>&nbsp;&nbsp;<code>"value" : "${}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br>        |
+> | `ATTRIBUTE_NAME`         | {<br>&nbsp;&nbsp;<code>"value" : "${orderId}",</code><br>&nbsp;&nbsp;"label" : "Input: orderId",<br>&nbsp;&nbsp;"type" : "String",<br>&nbsp;&nbsp;"editable" : true,<br>&nbsp;&nbsp;"binding" : {<br>&nbsp;&nbsp;&nbsp;&nbsp;"type" : "camunda:inputParameter",<br>&nbsp;&nbsp;&nbsp;&nbsp;"name" : "orderId"<br>&nbsp;&nbsp;}<br>}<br> |
 
 ### Annotations
 

--- a/connect/templates/generator-maven-plugin/src/main/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojo.java
+++ b/connect/templates/generator-maven-plugin/src/main/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojo.java
@@ -26,7 +26,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -35,7 +34,7 @@ import java.util.Set;
 /**
  * A maven mojo for generating element templates.
  */
-@Mojo(name = "generate", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "generate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class ElementTemplateGeneratorMojo extends AbstractMojo {
 
     private final Log log = getLog();
@@ -66,6 +65,9 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
         if (Objects.nonNull(skip) && skip) {
             getLog().info("Element-template generation is skipped.");
             return;
+        } else if (Objects.isNull(targetPlatforms) || targetPlatforms.length == 0) {
+            getLog().info("Element-template generation failed. Please configure a target platform. Valid target platforms are: camunda7 or camunda8");
+            return;
         }
 
         List<ElementTemplateGenerator> generators = ElementTemplateGeneratorsFactory.create(targetPlatforms);
@@ -89,8 +91,7 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
     }
 
     private void saveElementTemplateToFile(ElementTemplateGenerationResult generationResult) {
-        var path = Path.of(generationResult.getTargetPlatform().name(), generationResult.getFileName()).toString();
-        var elementTemplate = new File(outputDirectory, path);
+        var elementTemplate = new File(outputDirectory, generationResult.getFileName());
         boolean dirsCreated = elementTemplate.getParentFile().mkdirs();
         try {
             var fileCreated = elementTemplate.createNewFile();

--- a/connect/templates/generator-maven-plugin/src/main/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorsFactory.java
+++ b/connect/templates/generator-maven-plugin/src/main/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorsFactory.java
@@ -20,10 +20,10 @@ public class ElementTemplateGeneratorsFactory {
 
     public static ElementTemplateGenerator create(TargetPlatform targetPlatform) {
         switch (targetPlatform) {
-            case camunda7 -> {
+            case C7 -> {
                 return new Camunda7ElementTemplateGenerator();
             }
-            case camunda8 -> {
+            case C8 -> {
                 return new Camunda8ElementTemplateGenerator();
             }
         }

--- a/connect/templates/generator-maven-plugin/src/test/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojoTest.java
+++ b/connect/templates/generator-maven-plugin/src/test/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojoTest.java
@@ -75,15 +75,13 @@ class ElementTemplateGeneratorMojoTest {
             public void test() {
             }
         }
-        String filename = "test-0-1.json";
+        String filename = "test-v1.json";
 
         // Act
         mojo.execute();
 
         // Assert that file was generated for target
-        File platformDirectory = new File(mojo.outputDirectory, TargetPlatform.camunda7.name());
-        assertTrue(platformDirectory.exists());
-        assertTrue(new File(platformDirectory, filename).exists());
+        assertTrue(new File(mojo.outputDirectory, filename).exists());
     }
 
     @Test
@@ -108,18 +106,15 @@ class ElementTemplateGeneratorMojoTest {
             public void test2() {
             }
         }
-        String filename1 = "test1-0-1.json";
-        String filename2 = "test2-0-1.json";
+        String filename1 = "test1-v1.json";
+        String filename2 = "test2-v1.json";
 
         // Act
         mojo.execute();
 
         // Assert that files were generated for target
-        File platformDirectory = new File(mojo.outputDirectory, TargetPlatform.camunda7.name());
-        assertTrue(platformDirectory.exists());
-        assertTrue(new File(platformDirectory, filename1).exists());
+        assertTrue(new File(mojo.outputDirectory, filename1).exists());
 
-        assertTrue(platformDirectory.exists());
-        assertTrue(new File(platformDirectory, filename2).exists());
+        assertTrue(new File(mojo.outputDirectory, filename2).exists());
     }
 }

--- a/connect/templates/generator-maven-plugin/src/test/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojoTest.java
+++ b/connect/templates/generator-maven-plugin/src/test/java/io/miragon/miranum/connect/elementtemplate/ElementTemplateGeneratorMojoTest.java
@@ -47,7 +47,7 @@ class ElementTemplateGeneratorMojoTest {
     public void testExecuteWhenNoAnnotatedMethodsFound_ShouldNotGenerateElementTemplates() throws Exception {
         // Arrange
         mojo.skip = false;
-        mojo.targetPlatforms = new TargetPlatform[]{TargetPlatform.camunda7};
+        mojo.targetPlatform = TargetPlatform.C7;
 
         when(project.getCompileClasspathElements()).thenReturn(Collections.singletonList("test"));
 
@@ -62,7 +62,7 @@ class ElementTemplateGeneratorMojoTest {
     public void testExecuteWithSingleAnnotatedMethod_ShouldGenerateElementTemplate() throws Exception {
         // Arrange
         mojo.skip = false;
-        mojo.targetPlatforms = new TargetPlatform[]{TargetPlatform.camunda7};
+        mojo.targetPlatform = TargetPlatform.C8;
 
         // .class file gets generated in target/test-classes
         when(project.getCompileClasspathElements()).thenReturn(Collections.singletonList("target/test-classes"));
@@ -75,7 +75,7 @@ class ElementTemplateGeneratorMojoTest {
             public void test() {
             }
         }
-        String filename = "test-v1.json";
+        String filename = "test.json";
 
         // Act
         mojo.execute();
@@ -88,7 +88,7 @@ class ElementTemplateGeneratorMojoTest {
     public void testExecuteWithMultipleAnnotatedMethods_ShouldGenerateElementTemplate() throws Exception {
         // Arrange
         mojo.skip = false;
-        mojo.targetPlatforms = new TargetPlatform[]{TargetPlatform.camunda7};
+        mojo.targetPlatform = TargetPlatform.C7;
 
         // .class file gets generated in target/test-classes
         when(project.getCompileClasspathElements()).thenReturn(Collections.singletonList("target/test-classes"));
@@ -106,8 +106,8 @@ class ElementTemplateGeneratorMojoTest {
             public void test2() {
             }
         }
-        String filename1 = "test1-v1.json";
-        String filename2 = "test2-v1.json";
+        String filename1 = "test1.json";
+        String filename2 = "test2.json";
 
         // Act
         mojo.execute();
@@ -116,5 +116,31 @@ class ElementTemplateGeneratorMojoTest {
         assertTrue(new File(mojo.outputDirectory, filename1).exists());
 
         assertTrue(new File(mojo.outputDirectory, filename2).exists());
+    }
+
+    @Test
+    public void testExecuteWithSingleAnnotatedMethod_ShouldGenerateElementTemplateWithVersion() throws Exception {
+        // Arrange
+        mojo.skip = false;
+        mojo.targetPlatform = TargetPlatform.C8;
+
+        // .class file gets generated in target/test-classes
+        when(project.getCompileClasspathElements()).thenReturn(Collections.singletonList("target/test-classes"));
+
+        // Create a test class with a method annotated with @GenerateElementTemplate
+        class Test {
+
+            @Worker(type = "test")
+            @ElementTemplate(name = "Test", version = 1)
+            public void test() {
+            }
+        }
+        String filename = "test-v1.json";
+
+        // Act
+        mojo.execute();
+
+        // Assert that file was generated for target
+        assertTrue(new File(mojo.outputDirectory, filename).exists());
     }
 }


### PR DESCRIPTION
* better visibility if a field is a `inputParameter` or `outputParameter`
* interrupt generation and log error when no `targetPlatform` is given
* set `version` type to int
* remove `targetPlatform` as output directory